### PR TITLE
Added support for Azure OpenAI through JSON configuration and env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,6 +167,8 @@ moonshot/data/connectors-endpoints/*.json
 moonshot/data/results/*.json
 moonshot/data/databases/*.db
 moonshot/data/sessions/*.json
+moonshot/data/sessions/*.db
+moonshot/integrations/web_api/log/web_api.log.*
 
 # dev settings
 .vscode/

--- a/docs/cli/connecting_endpoints.md
+++ b/docs/cli/connecting_endpoints.md
@@ -10,8 +10,6 @@ Moonshot currently provides easy connection to: OpenAI's GPT4 & GPT3.5, GPT2 and
 
 To connect to these models, you simply need to create an endpoint configuration file under the directory `data/connectors-endpoints` and define the following fields in that file:
 
-
-
 - **type**: The python module name of LLM that you would like to connect to. (It should be any ONE of the Python modules available at `data/connectors`) 
 - **name**: The name of this endpoint (It should also be the name of this file)
 - **uri**: The URI of the LLM endpoint. 
@@ -19,7 +17,10 @@ To connect to these models, you simply need to create an endpoint configuration 
 - **max_calls_per_second**: The maximum number of API calls made to the LLM endpoint per second.
 - **max_concurrency**: The maximum number of open concurrent connections to the LLM endpoint.
 - **params**: The parameter(s) required to be sent to the LLM endpoint. (optional)
- 
+
+💡**Quick Start:** If you have an OpenAI API key, simply edit the pre-configured endpoint at `my-openai-gpt35.json`, and you'll be able to start evaluating or red-teaming GPT3.5. 
+
+### Example Connecting to Anthropic Claude
 For example, if you wish to create an endpoint configuration file to connect to Claude 2, you can create a file named `my-anthropic-claude2.json` in `data/connectors-endpoints`. The contents of `my-anthropic-claude2.json` should look something like this:
 
     {
@@ -31,9 +32,42 @@ For example, if you wish to create an endpoint configuration file to connect to 
         "max_concurrency": 100,
         "params": {}
     }
-💡**Quick Start:** If you have an OpenAI API key, simply edit the pre-configured endpoint at `my-openai-gpt35.json`, and you'll be able to start evaluating or red-teaming GPT3.5. 
 
-**Connecting LLMs - CLI Commands**
+### Example connecting to Azure OpenAI
+If you have an Azure OpenAI deployment, you can create a file named `my-azure-openai.json` in `data/connectors-endpoints`. The contents of `my-azure-openai.json` should look something like this:
+
+    {
+        "id": "my-azure-openai",
+        "name": "my-azure-openai",
+        "connector_type": "openai-azure",
+        "uri": "https://ADD_ENDPOINT_HERE.openai.azure.com",
+        "token": "ADD_NEW_TOKEN_HERE",
+        "max_calls_per_second": 10,
+        "max_concurrency": 2,
+        "params": {
+            "temperature": 0,
+            "deployment_id": "gpt-4-1106-preview",
+            "model": "gpt-4-1106-preview",
+            "api_version": "2024-03-01-preview"
+        }
+    }
+
+Certain environment variables can be used to override the JSON configuration, place these in your `.env` file:
+
+    # Azure OpenAI Service
+    OPENAI_API_TYPE="azure"
+    OPENAI_API_BASE="https://ADD_ENDPOINT_HERE.openai.azure.com"
+    OPENAI_API_KEY="ADD_NEW_TOKEN_HERE"
+    OPENAI_API_MODEL="gpt-4-1106-preview"
+    OPENAI_API_VERSION="2024-03-01-preview"
+
+Either the "uri" JSON parameter, or OPENAI_API_BASE environment variable, can be one of the following formats:
+
+    https://ADD_ENDPOINT_HERE.openai.azure.com
+
+    https://ADD_ENDPOINT_HERE.openai.azure.com/openai/deployments/ADD_DEPLOYMENT_ID_HERE
+
+### Connecting LLMs - CLI Commands
 ```bash                                                          
 list_connect_types    Get a list of available LLM connection types.
 add_endpoint          Add a new endpoint.

--- a/moonshot/data/connectors-endpoints/test-azure-openai-endpoint.json
+++ b/moonshot/data/connectors-endpoints/test-azure-openai-endpoint.json
@@ -1,0 +1,15 @@
+{
+  "id": "test-azure-openai-endpoint",
+  "name": "test-azure-openai-endpoint",
+  "connector_type": "openai-azure",
+  "uri": "https://ADD_ENDPOINT_HERE.openai.azure.com",
+  "token": "ADD_NEW_TOKEN_HERE",
+  "max_calls_per_second": 10,
+  "max_concurrency": 2,
+  "params": {
+    "temperature": 0,
+    "deployment_id": "gpt-4-1106-preview",
+    "model": "gpt-4-1106-preview",
+    "api_version": "2024-03-01-preview"
+  }
+}

--- a/moonshot/data/connectors/openai-azure.py
+++ b/moonshot/data/connectors/openai-azure.py
@@ -1,0 +1,126 @@
+import logging
+from typing import Any
+
+import openai
+import os
+
+from moonshot.src.connectors.connector import Connector, perform_retry
+from moonshot.src.connectors.connector_endpoint_arguments import (
+    ConnectorEndpointArguments,
+)
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+
+class OpenAIAzure(Connector):
+    def __init__(self, ep_arguments: ConnectorEndpointArguments):
+        # Initialize super class
+        super().__init__(ep_arguments)
+
+        # Look at the parameters and set sensible defaults
+        params = self.params
+        if 'temperature' in params:
+            try:
+                self.temperature = float(params['temperature'])
+            except ValueError:
+                logger.warn("Invalid temperature value. Using default value of 0.0")
+                self.temperature = 0.0
+        else:
+            self.temperature = 0.0
+
+        # Azure OpenAI model to use
+        if 'model' in params and len(params['model']) > 0:
+            self.model = params['model']
+        else:
+            self.model = None
+
+        # Azure OpenAI deployment_id to use
+        if 'deployment_id' in params and len(params['deployment_id']) > 0:
+            self.deployment_id = params['deployment_id']
+        else:
+            self.deployment_id = None
+
+        # 
+        # Environment variables override the connector endpoint configuration
+        #
+
+        if 'OPENAI_API_KEY' in os.environ and len(os.environ['OPENAI_API_KEY']) > 0:
+            self.token = os.environ['OPENAI_API_KEY']
+
+        if 'OPENAI_API_MODEL' in os.environ and len(os.environ['OPENAI_API_MODEL']) > 0:
+            self.model = os.environ['OPENAI_API_MODEL']
+            self.deployment_id = os.environ['OPENAI_API_MODEL']
+
+        if 'OPENAI_API_VERSION' in os.environ and len(os.environ['OPENAI_API_VERSION']) > 0:
+            self.api_version = os.environ['OPENAI_API_VERSION']
+        else:
+            self.api_version = "2024-03-01-preview" # Sensible default
+
+        # If 'OPENAI_API_BASE' is set, use it.
+        # Expected formats:
+        # https://aoa-sea-poc-eastus2.openai.azure.com
+        # https://aoa-sea-poc-eastus2.openai.azure.com/openai/deployments/gpt-4-1106-preview
+        if 'OPENAI_API_BASE' in os.environ and len(os.environ['OPENAI_API_BASE']) > 0:
+            self.endpoint = os.environ['OPENAI_API_BASE']
+
+        # Special case, check if self.endpoint contains "/openai/deployments/" and then extract the deployment_id
+        if "/openai/deployments/" in self.endpoint:
+            # Split the endpoint to extract the deployment_id
+            parts = self.endpoint.split("/openai/deployments/")
+            self.endpoint = parts[0]  # Update self.endpoint to the base URL
+            self.deployment_id = parts[1]  # Extract the deployment_id
+
+        # Sanity check
+        if self.deployment_id is None:
+            logger.error("Missing deployment_id parameter, or OPENAI_API_MODEL environment variable.")
+            raise ValueError("Missing deployment_id parameter, or OPENAI_API_MODEL environment variable.")
+        if self.model is None:
+            logger.error("Missing model parameter, or OPENAI_API_MODEL environment variable.")
+            raise ValueError("Missing model parameter, or OPENAI_API_MODEL environment variable.")
+
+        # This is how to initialise the openai library (v0.28.1) for Microsoft Azure Endpoints
+        # @see https://github.com/openai/openai-python/tree/v0.28.1
+        openai.api_type = "azure"
+        openai.api_key = self.token
+        openai.api_base = self.endpoint
+        openai.api_version = self.api_version
+
+
+    @Connector.rate_limited
+    @perform_retry
+    async def get_response(self, prompt: str) -> str:
+        """
+        Retrieve and return a response.
+        This method is used to retrieve a response, typically from an object or service represented by
+        the current instance.
+
+        Returns:
+            str: retrieved response data
+        """
+        connector_prompt = f"{self.pre_prompt}{prompt}{self.post_prompt}"
+        openai_request = [{"role": "user", "content": connector_prompt}]
+        response = await openai.ChatCompletion.acreate(
+            deployment_id=self.deployment_id,
+            model=self.model,
+            messages=openai_request,
+            temperature=self.temperature,
+            timeout=self.timeout,
+        )
+        return await self._process_response(response)
+
+    async def _process_response(self, response: Any) -> str:
+        """
+        Process an HTTP response and extract relevant information as a string.
+
+        This function takes an HTTP response object as input and processes it to extract
+        relevant information as a string. The extracted information may include data
+        from the response body, headers, or other attributes.
+
+        Args:
+            response (OpenAIObject): An HTTP response object containing the response data.
+
+        Returns:
+            str: A string representing the relevant information extracted from the response.
+        """
+        return response["choices"][0]["message"]["content"]


### PR DESCRIPTION
Hello team moonshot!

We have been testing against our production Azure OpenAI endpoints and would like to share the following amendments.

- Added a new `openai-azure.py` connector, this handles some oddities about using Azure with early versions of the `openai` library.
- Added an example `test-azure-openai-endpoint.json` configuration to illustrate all the accepted options.
- Updated the `docs/cli/connecting_endpoints.md` documentation to detail the options, and environment variables.
- Misc: added more ephemeral files to `.gitignore`.

Both JSON configuration and environment variable configurations have been tested and found to work as expected.

Please let us know if you have any questions, or further suggestions.