### PR TITLE
add changes to handle multiple operations

### DIFF
--- a/moonshot/src/runs/run_arguments.py
+++ b/moonshot/src/runs/run_arguments.py
@@ -25,6 +25,8 @@ class RunArguments(BaseModel):
 
     endpoints: list[str]  # List of endpoints for the Run.
 
+    results_id: str  # The unique identifier for the results of the Run.
+
     results_file: str  # The results file associated with the Run.
 
     start_time: float  # The start time of the Run.
@@ -47,9 +49,9 @@ class RunArguments(BaseModel):
 
         This method transforms the RunArguments instance into a dictionary, encapsulating all the critical attributes
         associated with the run. The resulting dictionary includes keys for runner_id, runner_type, runner_args,
-        database_instance, endpoints, results_file, start_time, end_time, duration, error_messages, raw_results,
-        results, and status offering a comprehensive snapshot of the run's parameters for straightforward access
-        and further processing.
+        database_instance, endpoints, results_id, results_file, start_time, end_time, duration, error_messages,
+        raw_results, results, and status offering a comprehensive snapshot of the run's parameters for
+        straightforward access and further processing.
 
         Returns:
             dict: A dictionary containing all the significant attributes of the RunArguments instance.
@@ -60,6 +62,7 @@ class RunArguments(BaseModel):
             "runner_type": self.runner_type,
             "runner_args": self.runner_args,
             "endpoints": self.endpoints,
+            "results_id": self.results_id,
             "results_file": self.results_file,
             "start_time": self.start_time,
             "end_time": self.end_time,
@@ -76,7 +79,7 @@ class RunArguments(BaseModel):
 
         This method prepares a tuple of run arguments that can be used to insert a new record into the run_table
         in the database. The tuple includes the runner_id, runner_type in lowercase, string representation of
-        runner_args, string representation of endpoints, results_file, start_time, end_time, duration,
+        runner_args, string representation of endpoints, results_id, results_file, start_time, end_time, duration,
         string representation of error_messages, string representation of raw_results, string representation of results,
         and the run status in lowercase.
 
@@ -88,6 +91,7 @@ class RunArguments(BaseModel):
             self.runner_type.name.lower(),
             str(self.runner_args),
             str(self.endpoints),
+            self.results_id,
             self.results_file,
             self.start_time,
             self.end_time,
@@ -104,8 +108,8 @@ class RunArguments(BaseModel):
 
         This method serializes the RunArguments instance to a tuple, encapsulating the primary attributes of the run.
         The resulting tuple contains the runner ID, runner type in lowercase, string representation of runner arguments,
-        string representation of endpoints, results file path, start time, end time, run duration, string representation
-        of error messages, string representation of raw results, string representation of results,
+        string representation of endpoints, results_id, results file path, start time, end time, run duration, string
+        representation of error messages, string representation of raw results, string representation of results,
         and the run status in lowercase. This provides a complete summary of the run's parameters for easy storage
         or transmission.
 
@@ -117,6 +121,7 @@ class RunArguments(BaseModel):
             self.runner_type.name.lower(),
             str(self.runner_args),
             str(self.endpoints),
+            self.results_id,
             self.results_file,
             self.start_time,
             self.end_time,
@@ -151,12 +156,13 @@ class RunArguments(BaseModel):
             runner_args=ast.literal_eval(run_record[3]),
             database_instance=None,
             endpoints=ast.literal_eval(run_record[4]),
-            results_file=run_record[5],
-            start_time=float(run_record[6]),
-            end_time=float(run_record[7]),
-            duration=run_record[8],
-            error_messages=ast.literal_eval(run_record[9]),
-            raw_results=ast.literal_eval(run_record[10]),
-            results=ast.literal_eval(run_record[11]),
-            status=RunStatus(run_record[12]),
+            results_id=run_record[5],
+            results_file=run_record[6],
+            start_time=float(run_record[7]),
+            end_time=float(run_record[8]),
+            duration=run_record[9],
+            error_messages=ast.literal_eval(run_record[10]),
+            raw_results=ast.literal_eval(run_record[11]),
+            results=ast.literal_eval(run_record[12]),
+            status=RunStatus(run_record[13]),
         )

--- a/moonshot/src/runs/run_progress.py
+++ b/moonshot/src/runs/run_progress.py
@@ -8,8 +8,8 @@ from moonshot.src.storage.storage import Storage
 
 class RunProgress:
     sql_update_run_record = """
-        UPDATE run_table SET runner_id=?,runner_type=?,runner_args=?,endpoints=?,results_file=?,start_time=?,end_time=?,
-        duration=?,error_messages=?,raw_results=?,results=?,status=?
+        UPDATE run_table SET runner_id=?,runner_type=?,runner_args=?,endpoints=?,results_id=?,results_file=?,
+        start_time=?,end_time=?,duration=?,error_messages=?,raw_results=?,results=?,status=?
         WHERE run_id=?
     """
 
@@ -118,22 +118,36 @@ class RunProgress:
 
     def get_dict(self) -> dict:
         """
-        Constructs and returns a dictionary with the current state of the benchmark execution.
+        Returns a dictionary representing the current state of the run progress.
 
-        This method assembles a dictionary encapsulating the current progress of the benchmark execution.
-        The resulting dictionary is composed of the following keys: execution identifier, name, type, current duration,
-        status, cookbook index, cookbook name, cookbook total, recipe index, recipe name, recipe total,
-        progress percentage, and a list of error messages.
+        This method creates a dictionary that reflects the current state of the run progress, including various
+        execution details and metrics. The keys in the dictionary include identifiers, status, indices, names,
+        totals, progress percentage, and error messages related to the execution.
 
         Returns:
-            dict: A dictionary representing the current benchmark execution state, with keys for various progress
-            metrics and details.
+            dict: A dictionary with the following structure:
+                - current_runner_id: Identifier of the current runner.
+                - current_runner_type: Type of the current runner.
+                - current_run_id: Identifier of the current run.
+                - current_duration: Elapsed duration of the current run.
+                - current_status: Status of the current run.
+                - current_result_file: File path for the results of the current run.
+                - current_cookbook_index: Index of the current cookbook.
+                - current_cookbook_name: Name of the current cookbook.
+                - current_cookbook_total: Total number of cookbooks.
+                - current_recipe_index: Index of the current recipe.
+                - current_recipe_name: Name of the current recipe.
+                - current_recipe_total: Total number of recipes.
+                - current_progress: Percentage of progress made in the current run.
+                - current_error_messages: List of error messages encountered during the run.
         """
         return {
             "current_runner_id": self.run_arguments.runner_id,
             "current_runner_type": self.run_arguments.runner_type.value,
+            "current_run_id": self.run_arguments.run_id,
             "current_duration": self.run_arguments.duration,
             "current_status": self.run_arguments.status.value,
+            "current_result_file": self.run_arguments.results_file,
             "current_cookbook_index": self.cookbook_index,
             "current_cookbook_name": self.cookbook_name,
             "current_cookbook_total": self.cookbook_total,


### PR DESCRIPTION
1. Modified to allow multiple operations to be run at the same time.
2. Benchmark results files will have <runner_id>-<run_id>.json
3. Red teaming is not tested yet.
4. Benchmark callback function will need to use run_id to differentiate 

Will need benchmarking.py to modify the mandatory values to set as self.run_progress.run_arguments.results_id

```
# ------------------------------------------------------------------------------
# Prepare ResultArguments
# ------------------------------------------------------------------------------
print("[Benchmarking] Preparing results...")
start_time = time.perf_counter()
result_args = None
try:
    result_args = ResultArguments(
        # Mandatory values
        id=self.run_progress.run_arguments.results_id,
        start_time=self.run_progress.run_arguments.start_time,
        ...
    )
```