### PR TITLE
Update quick_start.md to fix pdf download for mobile

### DIFF
--- a/docs/getting_started/quick_start.md
+++ b/docs/getting_started/quick_start.md
@@ -3,5 +3,5 @@
     Users are encouraged to install using the latest release on `pypi`.
 
 <object data="../quick-start-guide.pdf" type="application/pdf" width="100%" height="1000px">
-  <p>Unable to display PDF, <a href="../../res/quick-start-guide.pdf">click here to download it</a>.</p>
+  <p>Unable to display PDF, <a href="../quick-start-guide.pdf">click here to download it</a>.</p>
 </object>


### PR DESCRIPTION
This fixes the download of the quick start guide pdf for mobile