### PR TITLE
added optional param for run_attack_module in cli

### DIFF
--- a/moonshot/integrations/cli/redteam/session.py
+++ b/moonshot/integrations/cli/redteam/session.py
@@ -263,6 +263,9 @@ def run_attack_module(args):
         context_strategy = args.context_strategy or []
         prompt_template = [args.prompt_template] if args.prompt_template else []
         metric = [args.metric] if args.metric else []
+        optional_arguments = (
+            literal_eval(args.optional_args) if args.optional_args else {}
+        )
         num_of_prev_prompts = (
             args.num_of_prev_prompts
             if args.num_of_prev_prompts
@@ -288,6 +291,7 @@ def run_attack_module(args):
                 "context_strategy_info": context_strategy_info,
                 "prompt_template_ids": prompt_template,
                 "metric_ids": metric,
+                "optional_params": optional_arguments,
             }
         ]
         runner_args = {}
@@ -407,7 +411,8 @@ automated_rt_session_args = cmd2.Cmd2ArgumentParser(
     description="Runs automated red teaming in the current session.",
     epilog=(
         'Example:\n run_attack_module sample_attack_module "this is my prompt" -s "test system prompt" '
-        '-c "add_previous_prompt" -p "mmlu" -m "bleuscore"'
+        '-c "add_previous_prompt" -p "mmlu" -m "bleuscore" '
+        "-o \"{'max_number_of_iteration': 1, 'my_optional_param': 'hello world'}\""
     ),
 )
 
@@ -455,6 +460,13 @@ automated_rt_session_args.add_argument(
     "-m", "--metric", type=str, help="Name of the metric module to be used.", nargs="?"
 )
 
+automated_rt_session_args.add_argument(
+    "-o",
+    "--optional_args",
+    type=str,
+    help="Optional parameters to input into the red teaming module.",
+    nargs="?",
+)
 
 # Delete session arguments
 delete_session_args = cmd2.Cmd2ArgumentParser(

--- a/moonshot/src/redteaming/attack/attack_module.py
+++ b/moonshot/src/redteaming/attack/attack_module.py
@@ -40,7 +40,7 @@ class AttackModule:
             self.db_instance = am_arguments.db_instance
             self.red_teaming_progress = am_arguments.red_teaming_progress
             self.cancel_event = am_arguments.cancel_event
-            self.params = am_arguments.params
+            self.optional_params = am_arguments.optional_params
 
     @classmethod
     def load(

--- a/moonshot/src/redteaming/attack/attack_module_arguments.py
+++ b/moonshot/src/redteaming/attack/attack_module_arguments.py
@@ -41,4 +41,4 @@ class AttackModuleArguments(BaseModel):
     cancel_event: asyncio.Event
 
     # a dict that contains other params that is required by the attack module (if any)
-    params: dict = {}
+    optional_params: dict = {}

--- a/tests/others/functest_rt_api.py
+++ b/tests/others/functest_rt_api.py
@@ -189,11 +189,14 @@ def test_art_and_cancel():
                     "num_of_prev_prompts": 1
                     }],
                 "prompt_template_ids": ["mmlu"],
-                "metric_ids": ["bleuscore"] 
+                "metric_ids": ["bleuscore"],
+                "optional_params": {"max_number_of_iteration": 1, 
+                           "sample_param_field": "hello world"}
                 },
             ],
             "chat_batch_size": 5
         }
+
         # Run the recipes in a background task
         run_task = asyncio.create_task(runner.run_red_teaming(art_arguments))
 


### PR DESCRIPTION
This PR is to add optional parameters for users to use in their attack modules. The optional parameters will be entered by the user in the CLI in the form of a dictionary, which the attack modules can take in (i.e. users may want to decide how many iterations the attack module should run before stopping, so the dictionary can have a field like "max_no_of_iteration" which the attack module will read in)

How to test:
1. Start cli: `python -m moonshot cli interactive`
2. Create a new session: `new_session -h` and copy the help sample codes to create a new session with a new runner (change the connector endpoint to one you can access with your API key)
3. Inside the session, enter `run_attack_module sample_attack_module "test prompt" -o "{'max_number_of_iteration': 1, 'my_optional_param': 'hello world'}"`
4. The attack module should run without any error
