### PR TITLE
[MS-351] Fix bug where logger keeps displaying multiple repeated logs

### DIFF
--- a/moonshot/src/utils/log.py
+++ b/moonshot/src/utils/log.py
@@ -47,14 +47,20 @@ def configure_logger(name: str):
     logger.setLevel(log_level)
     logger.propagate = False
 
-    # Create a console handler
-    console_handler = logging.StreamHandler()
-    console_handler.setLevel(log_level)
-    console_handler.setFormatter(formatter)
-    logger.addHandler(console_handler)
+    # Check if there is already a stream handler
+    if not any(
+        isinstance(handler, logging.StreamHandler) for handler in logger.handlers
+    ):
+        # Create a console handler
+        console_handler = logging.StreamHandler()
+        console_handler.setLevel(log_level)
+        console_handler.setFormatter(formatter)
+        logger.addHandler(console_handler)
 
     # Create a file handler if required
-    if log_write_to_file:
+    if log_write_to_file and not any(
+        isinstance(handler, logging.FileHandler) for handler in logger.handlers
+    ):
         file_path = Path(".").joinpath(log_filename).with_suffix(log_extension)
         file_handler = logging.FileHandler(
             str(file_path)


### PR DESCRIPTION
## Description

When running run_recipe or run_cookbooks using cli command, the command line is flooded with repeated message such as the following:

```
moonshot > run_recipe "my new recipe runner" "['real-toxicity-prompts-completion']" "['openai-gpt35-turbo']" -n 10 -r 1 -s "You are an intelligent AI"
2024-07-27 17:05:27,967 [INFO][runner.py::run_recipes(354)] [Runner] my-new-recipe-runner - Running benchmark recipe run...
2024-07-27 17:05:28,002 [INFO][benchmarking.py::generate(158)] [Benchmarking] Running recipes (['real-toxicity-prompts-completion'])...
2024-07-27 17:05:28,002 [INFO][benchmarking.py::generate(158)] [Benchmarking] Running recipes (['real-toxicity-prompts-completion'])...
2024-07-27 17:05:28,002 [INFO][benchmarking.py::generate(158)] [Benchmarking] Running recipes (['real-toxicity-prompts-completion'])...
2024-07-27 17:05:28,002 [INFO][benchmarking.py::generate(158)] [Benchmarking] Running recipes (['real-toxicity-prompts-completion'])...
2024-07-27 17:05:28,002 [INFO][benchmarking.py::generate(162)] [Benchmarking] Running recipe real-toxicity-prompts-completion... (1/1)
2024-07-27 17:05:28,002 [INFO][benchmarking.py::generate(162)] [Benchmarking] Running recipe real-toxicity-prompts-completion... (1/1)
2024-07-27 17:05:28,002 [INFO][benchmarking.py::generate(162)] [Benchmarking] Running recipe real-toxicity-prompts-completion... (1/1)
2024-07-27 17:05:28,002 [INFO][benchmarking.py::generate(162)] [Benchmarking] Running recipe real-toxicity-prompts-completion... (1/1)
```

## Motivation and Context

To fix the bug where multiple repeated messages appear

## Type of Change

<!-- Select the appropriate type of change: -->
<!-- - feat: A new feature -->
- fix: A bug fix
<!-- - chore: Routine tasks, maintenance, or tooling changes -->
<!-- - docs: Documentation updates -->
<!-- - style: Code style changes (e.g., formatting, indentation) -->
<!-- - refactor: Code refactoring without changes in functionality -->
<!-- - test: Adding or modifying tests -->
<!-- - perf: Performance improvements -->
<!-- - ci: Changes to the CI/CD configuration or scripts -->
<!-- - other: Other changes that don't fit into the above categories -->

## How to Test

Use the cli and run 'run_recipe' command multiple times without exiting moonshot>
If you see multiple messages as mentioned above, this fix has failed.

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [x]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [ ]  I have followed the project's coding conventions and style guidelines.
- [ ]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [x]  I have performed a self-review of my own code.
- [x]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>