### PR TITLE
[MS-393] Stacktrace appear when unable to set environment variables

### DIFF
--- a/moonshot/src/configs/env_variables.py
+++ b/moonshot/src/configs/env_variables.py
@@ -39,7 +39,11 @@ class EnvironmentVars:
     ]
     BOOKMARKS = [
         env_vars.get(EnvVariables.BOOKMARKS.value),
-        str(importlib.resources.files(__app_name__).joinpath("data/generated-outputs/bookmarks")),
+        str(
+            importlib.resources.files(__app_name__).joinpath(
+                "data/generated-outputs/bookmarks"
+            )
+        ),
     ]
     CONNECTORS = [
         env_vars.get(EnvVariables.CONNECTORS.value),
@@ -144,8 +148,8 @@ class EnvironmentVars:
                     EnvironmentVars.__dict__[key][0] = str(given_path)
                 else:
                     logger.warning(
-                        f"Unable to set {key}. The provided path {given_path} does not exist. ",
-                        "The stock set will be used.",
+                        f"Unable to set {key}. The provided path {given_path} does not exist. "
+                        "The stock set will be used."
                     )
             else:
                 unset_keys.append(key)


### PR DESCRIPTION
## Description

Stack trace appear when trying to run `python -m moonshot cli interactive` when environment variables are set.

## Motivation and Context

When running cli and the environment variables are not set, a list of stack traces appears. 
This is due to a bug in the log.warning code.

```
--- Logging error ---

Traceback (most recent call last):

  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/logging/__init__.py", line 1110, in emit

    msg = self.format(record)

          ^^^^^^^^^^^^^^^^^^^

  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/logging/__init__.py", line 953, in format

    return fmt.format(record)

           ^^^^^^^^^^^^^^^^^^

  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/logging/__init__.py", line 687, in format

    record.message = record.getMessage()

                     ^^^^^^^^^^^^^^^^^^^

  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/logging/__init__.py", line 377, in getMessage

    msg = msg % self.args

          ~~~~^~~~~~~~~~~

TypeError: not all arguments converted during string formatting

Call stack:

  File "<frozen runpy>", line 198, in _run_module_as_main

  File "<frozen runpy>", line 88, in _run_code

  File "/Users/lionelteo/Documents/moonshot/moonshot/__main__.py", line 241, in <module>

    main()

  File "/Users/lionelteo/Documents/moonshot/moonshot/__main__.py", line 211, in main

    api_set_environment_variables(dotenv_values(args.env))

  File "/Users/lionelteo/Documents/moonshot/moonshot/src/api/api_environment_variables.py", line 17, in api_set_environment_variables

    EnvironmentVars.load_env(env_vars)

  File "/Users/lionelteo/Documents/moonshot/moonshot/src/configs/env_variables.py", line 146, in load_env

    logger.warning(

Message: 'Unable to set ATTACK_MODULES. The provided path moonshot-data/attack-modules does not exist. '

Arguments: ('The stock set will be used.',)
```

After fixed, it should look like this:
```
2024-08-06 13:55:52,168 [WARNING][env_variables.py::load_env(146)] Unable to set ATTACK_MODULES. The provided path moonshot-data/attack-modules does not exist. The stock set will be used.
2024-08-06 13:55:52,168 [WARNING][env_variables.py::load_env(146)] Unable to set BOOKMARKS. The provided path moonshot-data/generated-outputs/bookmarks does not exist. The stock set will be used. 
```

## Type of Change

<!-- Select the appropriate type of change: -->
<!-- - feat: A new feature -->
- fix: A bug fix
<!-- - chore: Routine tasks, maintenance, or tooling changes -->
<!-- - docs: Documentation updates -->
<!-- - style: Code style changes (e.g., formatting, indentation) -->
<!-- - refactor: Code refactoring without changes in functionality -->
<!-- - test: Adding or modifying tests -->
<!-- - perf: Performance improvements -->
<!-- - ci: Changes to the CI/CD configuration or scripts -->
<!-- - other: Other changes that don't fit into the above categories -->

## How to Test

`
python3 -m venv venv
source venv/bin/activate
cd moonshot
pip3 install -r requirements.txt
python3 -m moonshot cli interactive
`

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [x]  I have followed the project's coding conventions and style guidelines.
- [ ]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [x]  I have performed a self-review of my own code.
- [x]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>