### PR TITLE
[MS-357] Benchmarking no run table found error if runner does not have a run

### DIFF
--- a/moonshot/src/runs/run.py
+++ b/moonshot/src/runs/run.py
@@ -20,6 +20,7 @@ logger = configure_logger(__name__)
 
 
 class Run:
+    sql_table_name = "run_table"
     sql_create_run_table = """
         CREATE TABLE IF NOT EXISTS run_table (
         run_id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -146,6 +147,12 @@ class Run:
         """
         if not database_instance:
             raise RuntimeError("[Run] Database instance not provided.")
+
+        # Check that the table exists
+        if not Storage.check_database_table_exists(
+            database_instance, Run.sql_table_name
+        ):
+            return []
 
         all_run_arguments_info = Storage.read_database_records(
             database_instance,


### PR DESCRIPTION
## Description

This is a backend bug that triggers when a runner is created without having any benchmark runs. If a runner has no runs, when we do a list_runs, there’ll be an SQL error.

## Motivation and Context

The display of an exception is bad. When there are many red teaming runners with no benchmark runs, it will display a list of exceptions when user list_runs.

Performs a simple check on whether the run_table exists for the runner before querying it.

## Type of Change

<!-- Select the appropriate type of change: -->
<!-- - feat: A new feature -->
- fix: A bug fix
<!-- - chore: Routine tasks, maintenance, or tooling changes -->
<!-- - docs: Documentation updates -->
<!-- - style: Code style changes (e.g., formatting, indentation) -->
<!-- - refactor: Code refactoring without changes in functionality -->
<!-- - test: Adding or modifying tests -->
<!-- - perf: Performance improvements -->
<!-- - ci: Changes to the CI/CD configuration or scripts -->
<!-- - other: Other changes that don't fit into the above categories -->

## How to Test

Steps to reproduce:

Start ms in cli: python -m moonshot cli interactive

Create a new session with a new runner: new_session my-runner -e "['openai-gpt4']"

Do a list_runs

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [x]  I have followed the project's coding conventions and style guidelines.
- [ ]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [x]  I have performed a self-review of my own code.
- [x]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)
Before:
![ms-357-before](https://github.com/user-attachments/assets/5a92ce59-7aa4-4f23-961c-a26c6cfe4efa)

After:
![ms-357-after](https://github.com/user-attachments/assets/f75ab703-88c8-4612-a400-fb5ba22c6c57)

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>