### PR TITLE
[MS-484][[BE] Unable to run update_endpoint cli command] Fix update endpoint var name

### DIFF
--- a/moonshot/integrations/cli/cli_errors.py
+++ b/moonshot/integrations/cli/cli_errors.py
@@ -392,10 +392,10 @@ ERROR_COMMON_UPDATE_ENDPOINT_ENDPOINT_VALIDATION = (
     "The 'endpoint' argument must be a non-empty string and not None."
 )
 ERROR_COMMON_UPDATE_ENDPOINT_VALUES_VALIDATION = (
-    "The 'update_values' argument must be a non-empty string and not None."
+    "The 'update_kwargs' argument must be a non-empty string and not None."
 )
 ERROR_COMMON_UPDATE_ENDPOINT_VALUES_VALIDATION_1 = (
-    "The 'update_values' argument must evaluate to a list of tuples."
+    "The 'update_kwargs' argument must evaluate to a list of tuples."
 )
 
 # ------------------------------------------------------------------------------

--- a/moonshot/integrations/cli/common/connectors.py
+++ b/moonshot/integrations/cli/common/connectors.py
@@ -465,7 +465,7 @@ update_endpoint_args = cmd2.Cmd2ArgumentParser(
         "  params: Extra arguments for the endpoint\n\n"
         "Example:\n"
         "  update_endpoint openai-gpt4 \"[('name', 'my-special-openai-endpoint'), "
-        "('uri', 'my-uri-loc'), ('token', 'my-token-here')]\""
+        "('uri', 'my-uri-loc'), ('token', 'my-token-here'), ('params', {'hello': 'world'})]\""
     ),
 )
 update_endpoint_args.add_argument(

--- a/moonshot/integrations/cli/common/connectors.py
+++ b/moonshot/integrations/cli/common/connectors.py
@@ -280,19 +280,19 @@ def update_endpoint(args) -> None:
         endpoint = args.endpoint
 
         if (
-            args.update_values is None
-            or not isinstance(args.update_values, str)
-            or not args.update_values
+            args.update_kwargs is None
+            or not isinstance(args.update_kwargs, str)
+            or not args.update_kwargs
         ):
             raise ValueError(ERROR_COMMON_UPDATE_ENDPOINT_VALUES_VALIDATION)
 
-        if literal_eval(args.update_values) and all(
-            isinstance(i, tuple) for i in literal_eval(args.update_values)
+        if literal_eval(args.update_kwargs) and all(
+            isinstance(i, tuple) for i in literal_eval(args.update_kwargs)
         ):
-            update_values = dict(literal_eval(args.update_values))
+            update_kwargs = dict(literal_eval(args.update_kwargs))
         else:
             raise ValueError(ERROR_COMMON_UPDATE_ENDPOINT_VALUES_VALIDATION_1)
-        api_update_endpoint(endpoint, **update_values)
+        api_update_endpoint(endpoint, **update_kwargs)
         print("[update_endpoint]: Endpoint updated.")
     except Exception as e:
         print(f"[update_endpoint]: {str(e)}")

--- a/tests/unit-tests/cli/test_common_endpoints.py
+++ b/tests/unit-tests/cli/test_common_endpoints.py
@@ -1193,7 +1193,7 @@ class TestCollectionCliConnectors:
     # Update Endpoint 
     # ------------------------------------------------------------------------------
     @pytest.mark.parametrize(
-        "endpoint, update_values, expected_log, to_be_called",
+        "endpoint, update_kwargs, expected_log, to_be_called",
         [
             # Valid case - Full update
             (
@@ -1249,55 +1249,55 @@ class TestCollectionCliConnectors:
             (
                 "Endpoint 1",
                 "['', '']",
-                "[update_endpoint]: The 'update_values' argument must evaluate to a list of tuples.",
+                "[update_endpoint]: The 'update_kwargs' argument must evaluate to a list of tuples.",
                 False
             ),
             (
                 "Endpoint 1",
                 "[[], ()]",
-                "[update_endpoint]: The 'update_values' argument must evaluate to a list of tuples.",
+                "[update_endpoint]: The 'update_kwargs' argument must evaluate to a list of tuples.",
                 False
             ),
             (
                 "Endpoint 1",
                 "",
-                "[update_endpoint]: The 'update_values' argument must be a non-empty string and not None.",
+                "[update_endpoint]: The 'update_kwargs' argument must be a non-empty string and not None.",
                 False
             ),            
             (
                 "Endpoint 1",  
                 None,
-                "[update_endpoint]: The 'update_values' argument must be a non-empty string and not None.",
+                "[update_endpoint]: The 'update_kwargs' argument must be a non-empty string and not None.",
                 False
             ),
             (
                 "Endpoint 1",
                 123,
-                "[update_endpoint]: The 'update_values' argument must be a non-empty string and not None.",
+                "[update_endpoint]: The 'update_kwargs' argument must be a non-empty string and not None.",
                 False
             ),
             (
                 "Endpoint 1",
                 {},
-                "[update_endpoint]: The 'update_values' argument must be a non-empty string and not None.",
+                "[update_endpoint]: The 'update_kwargs' argument must be a non-empty string and not None.",
                 False
             ),
             (
                 "Endpoint 1",
                 [],
-                "[update_endpoint]: The 'update_values' argument must be a non-empty string and not None.",
+                "[update_endpoint]: The 'update_kwargs' argument must be a non-empty string and not None.",
                 False
             ),
             (
                 "Endpoint 1",
                 (),
-                "[update_endpoint]: The 'update_values' argument must be a non-empty string and not None.",
+                "[update_endpoint]: The 'update_kwargs' argument must be a non-empty string and not None.",
                 False
             ),
             (
                 "Endpoint 1",
                 True,
-                "[update_endpoint]: The 'update_values' argument must be a non-empty string and not None.",
+                "[update_endpoint]: The 'update_kwargs' argument must be a non-empty string and not None.",
                 False
             ),
             # Test case: API update raises an exception
@@ -1310,7 +1310,7 @@ class TestCollectionCliConnectors:
         ]
     )
     @patch('moonshot.integrations.cli.common.connectors.api_update_endpoint')
-    def test_update_endpoint(self, mock_api_update_endpoint, capsys, endpoint, update_values, expected_log, to_be_called):
+    def test_update_endpoint(self, mock_api_update_endpoint, capsys, endpoint, update_kwargs, expected_log, to_be_called):
         if "error" in expected_log:
             mock_api_update_endpoint.side_effect = Exception(
                 "An error has occurred while updating the endpoint."
@@ -1321,7 +1321,7 @@ class TestCollectionCliConnectors:
 
         args = Namespace(
             endpoint = endpoint,
-            update_values = update_values
+            update_kwargs = update_kwargs
         )
 
         update_endpoint(args)
@@ -1331,7 +1331,7 @@ class TestCollectionCliConnectors:
 
         if to_be_called:
             mock_api_update_endpoint.assert_called_once_with(
-                args.endpoint, **dict(literal_eval(args.update_values))
+                args.endpoint, **dict(literal_eval(args.update_kwargs))
             )
         else:
             mock_api_update_endpoint.assert_not_called()    


### PR DESCRIPTION
## Description

To revert an accidental update on the variable name in update_endpoint CLI command

## Motivation and Context

To fix the error in CLI update_endpoint

## Type of Change


 fix: A bug fix
1. `python -m moonshot cli interactive`
2. Then enter `update_endpoint -h` and use the help example to update the endpoint. The endpoint should get updated successfully. 

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [x]  I have added appropriate unit tests or functional tests for the changes made.
- [ ]  I have followed the project's coding conventions and style guidelines.
- [ ]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [x]  I have performed a self-review of my own code.
- [x]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)



## Additional Notes


<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>