### PR TITLE
[MS-492] Moonshot dependency reinstallation

### DIFF
--- a/moonshot/__main__.py
+++ b/moonshot/__main__.py
@@ -116,7 +116,7 @@ def download_nltk_resources() -> None:
             raise
 
 
-def moonshot_data_installation() -> None:
+def moonshot_data_installation(force_reinstall: bool) -> None:
     # Code for moonshot-data installation
     logger.info("Installing Moonshot Data from GitHub")
     repo = "https://github.com/aiverify-foundation/moonshot-data.git"
@@ -124,21 +124,24 @@ def moonshot_data_installation() -> None:
 
     # Check if the directory already exists
     if os.path.exists(folder_name):
-        logger.warning(f"Directory {folder_name} already exists.")
-        user_input = (
-            input(
-                f"Directory {folder_name} already exists. Do you want to remove it and reinstall? (Y/n): "
-            )
-            .strip()
-            .lower()
-        )
-        if user_input == "y":
-            logger.info(f"Removing directory {folder_name}.")
-            # Remove the existing directory
+        if force_reinstall:
+            logger.info(f"Removing directory {folder_name} due to --force-reinstall flag.")
             shutil.rmtree(folder_name)
         else:
-            logger.info("Exiting function without removing the directory.")
-            return
+            logger.warning(f"Directory {folder_name} already exists.")
+            user_input = (
+                input(
+                    f"Directory {folder_name} already exists. Do you want to remove it and reinstall? (Y/n): "
+                )
+                .strip()
+                .lower()
+            )
+            if user_input == "y":
+                logger.info(f"Removing directory {folder_name}.")
+                shutil.rmtree(folder_name)
+            else:
+                logger.info("Exiting function without removing the directory.")
+                return
 
     logger.info(f"Cloning {repo}")
     # Clone the repository
@@ -176,7 +179,7 @@ def check_node() -> bool:
         return False
 
 
-def moonshot_ui_installation() -> None:
+def moonshot_ui_installation(force_reinstall: bool) -> None:
     if not check_node():
         logger.error("Node.js is not installed. Please install Node.js to proceed.")
         return
@@ -187,21 +190,24 @@ def moonshot_ui_installation() -> None:
 
     # Check if the directory already exists
     if os.path.exists(folder_name):
-        logger.warning(f"Directory {folder_name} already exists.")
-        user_input = (
-            input(
-                f"Directory {folder_name} already exists. Do you want to remove it and reinstall? (Y/n): "
-            )
-            .strip()
-            .lower()
-        )
-        if user_input == "y":
-            logger.info(f"Removing directory {folder_name}.")
-            # Remove the existing directory
+        if force_reinstall:
+            logger.info(f"Removing directory {folder_name} due to --force-reinstall flag.")
             shutil.rmtree(folder_name)
         else:
-            logger.info("Exiting function without removing the directory.")
-            return
+            logger.warning(f"Directory {folder_name} already exists.")
+            user_input = (
+                input(
+                    f"Directory {folder_name} already exists. Do you want to remove it and reinstall? (Y/n): "
+                )
+                .strip()
+                .lower()
+            )
+            if user_input == "y":
+                logger.info(f"Removing directory {folder_name}.")
+                shutil.rmtree(folder_name)
+            else:
+                logger.info("Exiting function without removing the directory.")
+                return
 
     logger.info(f"Cloning {repo}")
     # Clone the repository
@@ -262,15 +268,20 @@ def main() -> None:
     parser.add_argument(
         "-e", "--env", type=str, help="Path to the .env file", default=".env"
     )
+    parser.add_argument(
+        "--force-reinstall",
+        action="store_true",
+        help="Force reinstallation of modules without user interaction",
+    )
 
     args = parser.parse_args()
 
     # Handle installations based on the -i include arguments
     if "moonshot-data" in args.install:
-        moonshot_data_installation()
+        moonshot_data_installation(args.force_reinstall)
 
     if "moonshot-ui" in args.install:
-        moonshot_ui_installation()
+        moonshot_ui_installation(args.force_reinstall)
 
     # If mode is not specified, skip running any modes
     if args.mode is None:

--- a/moonshot/__main__.py
+++ b/moonshot/__main__.py
@@ -117,7 +117,17 @@ def download_nltk_resources() -> None:
 
 
 def moonshot_data_installation(unattended: bool, overwrite: bool) -> None:
-    # Code for moonshot-data installation
+    """
+    Install Moonshot Data from GitHub.
+
+    This function clones the Moonshot Data repository from GitHub, installs its requirements,
+    and sets up the necessary environment. If the target directory already exists, it handles
+    the situation based on the 'unattended' and 'overwrite' flags.
+
+    Args:
+        unattended (bool): If True, the function will not prompt the user for input.
+        overwrite (bool): If True, the existing directory will be removed before installation.
+    """
     logger.info("Installing Moonshot Data from GitHub")
     repo = "https://github.com/aiverify-foundation/moonshot-data.git"
     folder_name = repo.split("/")[-1].replace(".git", "")
@@ -168,7 +178,6 @@ def moonshot_data_installation(unattended: bool, overwrite: bool) -> None:
 
     # Change back to the base directory
     os.chdir("..")
-
 
 def check_node() -> bool:
     """


### PR DESCRIPTION
## Description

This change would allow user to reinstall moonshot-data and -ui in unattended mode. 

## Motivation and Context

This is to allow more flexibility to support CICD pipelines

## Type of Change

<!-- - feat: A new feature -->

## How to Test
You can test this with either moonshot-ui or moonshot-data or both. 

1. You can freshly install moonshot-ui or moonshot-data. 
2. After installing for the first step, run the same installation command. You should be able to see the prompt Y/n to replace existing folder or not.
3. If you press n, if it continue on with installing the requirements without replacing your existing folder.
4. If you press Y, it would remove the existing folder and install the new repo and requirements.
5. You can now try running the installation with the -o flag. (e.g. `python -m moonshot -i moonshot-data -o`,  it will remove the existing folder and reinstall the new repo and requirements without asking for user input. 
6. You can now try running the installation with the -u flag (e.g. `python -m moonshot -i moonshot-data -u`. You will see a message that says `"Unattended mode detected. To reinstall, please use the --overwrite flag."` .  And it will proceed with installing the requirements. 
7. You can now try running the installation with both the -o and -u flag (e.g. `python -m moonshot -i moonshot-data -u -o`. It will now remove the existing folder and reinstall the new repo without asking for user input.  And also reinstall the new requirements.

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [x]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have rebased my branch onto the latest commit of the main branch.
- [x]  I have squashed or reorganized my commits into logical units.
- [x]  I have added any necessary dependencies or packages to the project's build configuration.
- [x]  I have performed a self-review of my own code.
- [ ]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>