### PR TITLE
[MS-531] Fix bookmark unit tests

### DIFF
--- a/tests/unit-tests/src/test_bookmark.py
+++ b/tests/unit-tests/src/test_bookmark.py
@@ -423,17 +423,19 @@ class TestCollectionBookmark:
     # Test delete_bookmark functionality
     # ------------------------------------------------------------------------------
     @pytest.mark.parametrize(
-        "mock_side_effect, bookmark_name, expected_output, expected_call",
+        "mock_read_database_side_effect, mock_delete_database_side_effect, bookmark_name, expected_output, expected_call",
         [
-            # # Case where the bookmark is deleted successfully
-            # (
-            #     None,
-            #     "Bookmark A",
-            #     {"success": True, "message": "[Bookmark] Bookmark record deleted."},
-            #     True,
-            # ),
+            # Case where the bookmark is deleted successfully
+            (
+                ("database_record","result"),
+                None,
+                "Bookmark A",
+                {"success": True, "message": "[Bookmark] Bookmark record deleted."},
+                True,
+            ),
             # Case where the bookmark_name is invalid (None)
             (
+                ("database_record","result"),
                 None,
                 None,
                 {"success": False, "message": "[Bookmark] Invalid bookmark name: None"},
@@ -441,6 +443,7 @@ class TestCollectionBookmark:
             ),
             # Case where the bookmark_name is invalid (empty string)
             (
+                ("database_record","result"),
                 None,
                 "",
                 {"success": False, "message": "[Bookmark] Invalid bookmark name: "},
@@ -448,6 +451,7 @@ class TestCollectionBookmark:
             ),
             # Case where the bookmark_name is invalid (tuple)
             (
+                ("database_record","result"),
                 None,
                 (),
                 {"success": False, "message": "[Bookmark] Invalid bookmark name: ()"},
@@ -455,6 +459,7 @@ class TestCollectionBookmark:
             ),
             # Case where the bookmark_name is invalid (list)
             (
+                ("database_record","result"),
                 None,
                 [],
                 {"success": False, "message": "[Bookmark] Invalid bookmark name: []"},
@@ -462,6 +467,7 @@ class TestCollectionBookmark:
             ),
             # Case where the bookmark_name is invalid (dictionary)
             (
+                ("database_record","result"),
                 None,
                 {},
                 {"success": False, "message": "[Bookmark] Invalid bookmark name: {}"},
@@ -469,36 +475,44 @@ class TestCollectionBookmark:
             ),
             # Case where the bookmark_name is invalid (integer)
             (
+                ("database_record","result"),
                 None,
                 123,
                 {"success": False, "message": "[Bookmark] Invalid bookmark name: 123"},
                 False,
             ),
-            # # Case where deletion fails
-            # (
-            #     Exception("Deletion error"),
-            #     "Bookmark A",
-            #     {
-            #         "success": False,
-            #         "message": "[Bookmark] Failed to delete bookmark record: Deletion error",
-            #     },
-            #     True,
-            # ),
+            # Case where deletion fails
+            (
+                ("database_record","result"),
+                Exception("Deletion error"),
+                "Bookmark A",
+                {
+                    "success": False,
+                    "message": "[Bookmark] Failed to delete bookmark record: Deletion error",
+                },
+                True,
+            ),
         ],
     )
     @patch("moonshot.src.storage.storage.Storage.delete_database_record_in_table")
+    @patch("moonshot.src.storage.storage.Storage.read_database_record")
     def test_delete_bookmark(
         self,
+        mock_read_database_record_in_table,
         mock_delete_database_record_in_table,
-        mock_side_effect,
+        mock_read_database_side_effect,
+        mock_delete_database_side_effect,
         bookmark_name,
         expected_output,
         expected_call,
     ):
         bookmark_instance = Bookmark()
 
+        # Set up the mock side effect for read_database_record_in_table
+        mock_read_database_record_in_table.side_effect = mock_read_database_side_effect
+
         # Set up the mock side effect for delete_database_record_in_table
-        mock_delete_database_record_in_table.side_effect = mock_side_effect
+        mock_delete_database_record_in_table.side_effect = mock_delete_database_side_effect
 
         # Call the API function to delete the bookmark
         result = bookmark_instance.delete_bookmark(bookmark_name)


### PR DESCRIPTION
## Description

With some changes on deletion of bookmarks, 2 of the delete_bookmark functionality unit test broke.

## Motivation and Context

With some changes on deletion of bookmarks, 2 of the delete_bookmark functionality unit test broke.

## Type of Change

<!-- Select the appropriate type of change: -->
<!-- - feat: A new feature -->
<!-- - fix: A bug fix -->
<!-- - chore: Routine tasks, maintenance, or tooling changes -->
<!-- - docs: Documentation updates -->
<!-- - style: Code style changes (e.g., formatting, indentation) -->
<!-- - refactor: Code refactoring without changes in functionality -->
- test: Adding or modifying tests
<!-- - perf: Performance improvements -->
<!-- - ci: Changes to the CI/CD configuration or scripts -->
<!-- - other: Other changes that don't fit into the above categories -->

## How to Test

run the script ./run_unit_test.sh

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [x]  I have added appropriate unit tests or functional tests for the changes made.
- [ ]  I have followed the project's coding conventions and style guidelines.
- [ ]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [x]  I have performed a self-review of my own code.
- [x]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>