### PR TITLE
[MS-667] Bug fix for view_cookbook

### DIFF
--- a/moonshot/integrations/cli/benchmark/cookbook.py
+++ b/moonshot/integrations/cli/benchmark/cookbook.py
@@ -467,7 +467,10 @@ def _display_view_cookbook(cookbook_info):
     recipes_list = api_read_recipes(recipes)
     if recipes_list:
         table = Table(
-            title="View Cookbook", show_lines=True, expand=True, header_style="bold"
+            title=f'Cookbook "{name}"',
+            show_lines=True,
+            expand=True,
+            header_style="bold",
         )
         table.add_column("No.", width=2)
         table.add_column("Recipe", justify="left", width=78)
@@ -482,7 +485,6 @@ def _display_view_cookbook(cookbook_info):
                 datasets,
                 prompt_templates,
                 metrics,
-                attack_strategies,
                 grading_scale,
                 stats,
             ) = recipe.values()
@@ -494,9 +496,6 @@ def _display_view_cookbook(cookbook_info):
                 "Prompt Templates", prompt_templates
             )
             metrics_info = display_view_list_format("Metrics", metrics)
-            attack_strategies_info = display_view_list_format(
-                "Attack Strategies", attack_strategies
-            )
             grading_scale_info = _display_view_grading_scale_format(
                 "Grading Scale", grading_scale
             )
@@ -506,7 +505,9 @@ def _display_view_cookbook(cookbook_info):
                 f"[red]id: {id}[/red]\n\n[blue]{name}[/blue]\n{description}\n\n"
                 f"{tags_info}\n\n{categories_info}\n\n{grading_scale_info}\n\n{stats_info}"
             )
-            contains_info = f"{datasets_info}\n\n{prompt_templates_info}\n\n{metrics_info}\n\n{attack_strategies_info}"
+            contains_info = (
+                f"{datasets_info}\n\n{prompt_templates_info}\n\n{metrics_info}"
+            )
 
             table.add_section()
             table.add_row(str(recipe_id), recipe_info, contains_info)


### PR DESCRIPTION
## Description

There were remnants of attack module codes in view_cookbook that caused an error while viewing cookbooks.

## Motivation and Context

Bug fix

## Type of Change
A bug fix

## How to Test

1. Start MS in CLI
2. Enter `view_cookbook clcc-cookbook`. There should be no errors

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [x]  I have performed a self-review of my own code.
- [x]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>