### PR TITLE
[MS-668] Fix view_bookmark bug

### DIFF
--- a/moonshot/src/bookmark/bookmark.py
+++ b/moonshot/src/bookmark/bookmark.py
@@ -11,9 +11,9 @@ from moonshot.src.messages_constants import (
     BOOKMARK_ADD_BOOKMARK_VALIDATION_ERROR,
     BOOKMARK_DELETE_ALL_BOOKMARK_ERROR,
     BOOKMARK_DELETE_ALL_BOOKMARK_SUCCESS,
-    BOOKMARK_DELETE_BOOKMARK_FAIL,
     BOOKMARK_DELETE_BOOKMARK_ERROR,
     BOOKMARK_DELETE_BOOKMARK_ERROR_1,
+    BOOKMARK_DELETE_BOOKMARK_FAIL,
     BOOKMARK_DELETE_BOOKMARK_SUCCESS,
     BOOKMARK_EXPORT_BOOKMARK_ERROR,
     BOOKMARK_EXPORT_BOOKMARK_VALIDATION_ERROR,
@@ -186,7 +186,9 @@ class Bookmark:
             if (
                 bookmark_info is not None
                 and isinstance(bookmark_info, tuple)
-                and all(isinstance(item, str) for item in bookmark_info)
+                and all(
+                    isinstance(item, str) for item in bookmark_info[1:]
+                )  # Check if the rest are strings besides id
             ):
                 return BookmarkArguments.from_tuple_to_dict(bookmark_info)
             else:
@@ -210,9 +212,11 @@ class Bookmark:
         """
         if isinstance(bookmark_name, str) and bookmark_name:
             try:
-
                 bookmark_info = Storage.read_database_record(
-                self.db_instance, (bookmark_name,), Bookmark.sql_select_bookmark_record)
+                    self.db_instance,
+                    (bookmark_name,),
+                    Bookmark.sql_select_bookmark_record,
+                )
                 if bookmark_info is not None:
                     sql_delete_bookmark_record = textwrap.dedent(
                         f"""
@@ -222,7 +226,10 @@ class Bookmark:
                     Storage.delete_database_record_in_table(
                         self.db_instance, sql_delete_bookmark_record
                     )
-                    return {"success": True, "message": BOOKMARK_DELETE_BOOKMARK_SUCCESS}
+                    return {
+                        "success": True,
+                        "message": BOOKMARK_DELETE_BOOKMARK_SUCCESS,
+                    }
                 else:
                     return {"success": False, "message": BOOKMARK_DELETE_BOOKMARK_FAIL}
             except Exception as e:


### PR DESCRIPTION
## Description

Bug is causing view_bookmark not to show an existing bookmark

## Motivation and Context

Bug fix

## Type of Change
A bug fix

## How to Test

1. Start MS in CLI
2. Start a session, send a manual prompt to any model and bookmark the prompt
3. Then, use the `view_bookmark` command to view the bookmark. The bookmark should show

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [x]  I have followed the project's coding conventions and style guidelines.
- [ ]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [x]  I have performed a self-review of my own code.
- [x]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)


## Additional Notes


<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>