### PR TITLE
[MOON-496] Move error messages back to individual files

### DIFF
--- a/moonshot/src/bookmark/bookmark.py
+++ b/moonshot/src/bookmark/bookmark.py
@@ -5,21 +5,6 @@ from datetime import datetime
 
 from moonshot.src.bookmark.bookmark_arguments import BookmarkArguments
 from moonshot.src.configs.env_variables import EnvVariables
-from moonshot.src.messages_constants import (
-    BOOKMARK_ADD_BOOKMARK_ERROR,
-    BOOKMARK_ADD_BOOKMARK_SUCCESS,
-    BOOKMARK_ADD_BOOKMARK_VALIDATION_ERROR,
-    BOOKMARK_DELETE_ALL_BOOKMARK_ERROR,
-    BOOKMARK_DELETE_ALL_BOOKMARK_SUCCESS,
-    BOOKMARK_DELETE_BOOKMARK_ERROR,
-    BOOKMARK_DELETE_BOOKMARK_ERROR_1,
-    BOOKMARK_DELETE_BOOKMARK_FAIL,
-    BOOKMARK_DELETE_BOOKMARK_SUCCESS,
-    BOOKMARK_EXPORT_BOOKMARK_ERROR,
-    BOOKMARK_EXPORT_BOOKMARK_VALIDATION_ERROR,
-    BOOKMARK_GET_BOOKMARK_ERROR,
-    BOOKMARK_GET_BOOKMARK_ERROR_1,
-)
 from moonshot.src.storage.storage import Storage
 from moonshot.src.utils.log import configure_logger
 
@@ -28,6 +13,29 @@ logger = configure_logger(__name__)
 
 
 class Bookmark:
+    BOOKMARK_ADD_BOOKMARK_ERROR = "[Bookmark] Failed to add bookmark record: {message}"
+    BOOKMARK_ADD_BOOKMARK_SUCCESS = "[Bookmark] Bookmark added successfully."
+    BOOKMARK_ADD_BOOKMARK_VALIDATION_ERROR = "Error inserting record into database."
+    BOOKMARK_DELETE_ALL_BOOKMARK_ERROR = (
+        "[Bookmark] Failed to delete all bookmark records: {message}"
+    )
+    BOOKMARK_DELETE_ALL_BOOKMARK_SUCCESS = "[Bookmark] All bookmark records deleted."
+    BOOKMARK_DELETE_BOOKMARK_ERROR = (
+        "[Bookmark] Failed to delete bookmark record: {message}"
+    )
+    BOOKMARK_DELETE_BOOKMARK_ERROR_1 = "[Bookmark] Invalid bookmark name: {message}"
+    BOOKMARK_DELETE_BOOKMARK_FAIL = (
+        "[Bookmark] Bookmark record not found. Unable to delete."
+    )
+    BOOKMARK_DELETE_BOOKMARK_SUCCESS = "[Bookmark] Bookmark record deleted."
+    BOOKMARK_EXPORT_BOOKMARK_ERROR = "[Bookmark] Failed to export bookmarks: {message}"
+    BOOKMARK_EXPORT_BOOKMARK_VALIDATION_ERROR = (
+        "Export filename must be a non-empty string."
+    )
+    BOOKMARK_GET_BOOKMARK_ERROR = (
+        "[Bookmark] No record found for bookmark name: {message}"
+    )
+    BOOKMARK_GET_BOOKMARK_ERROR_1 = "[Bookmark] Invalid bookmark name: {message}"
     _instance = None
 
     sql_table_name = "bookmark"
@@ -135,13 +143,16 @@ class Bookmark:
                 self.db_instance, data, Bookmark.sql_insert_bookmark_record
             )
             if results is not None:
-                return {"success": True, "message": BOOKMARK_ADD_BOOKMARK_SUCCESS}
+                return {
+                    "success": True,
+                    "message": Bookmark.BOOKMARK_ADD_BOOKMARK_SUCCESS,
+                }
             else:
-                raise Exception(BOOKMARK_ADD_BOOKMARK_VALIDATION_ERROR)
+                raise Exception(Bookmark.BOOKMARK_ADD_BOOKMARK_VALIDATION_ERROR)
         except Exception as e:
             return {
                 "success": False,
-                "message": BOOKMARK_ADD_BOOKMARK_ERROR.format(message=str(e)),
+                "message": Bookmark.BOOKMARK_ADD_BOOKMARK_ERROR.format(message=str(e)),
             }
 
     def get_all_bookmarks(self) -> list[dict]:
@@ -193,11 +204,11 @@ class Bookmark:
                 return BookmarkArguments.from_tuple_to_dict(bookmark_info)
             else:
                 raise RuntimeError(
-                    BOOKMARK_GET_BOOKMARK_ERROR.format(message=bookmark_name)
+                    Bookmark.BOOKMARK_GET_BOOKMARK_ERROR.format(message=bookmark_name)
                 )
         else:
             raise RuntimeError(
-                BOOKMARK_GET_BOOKMARK_ERROR_1.format(message=bookmark_name)
+                Bookmark.BOOKMARK_GET_BOOKMARK_ERROR_1.format(message=bookmark_name)
             )
 
     def delete_bookmark(self, bookmark_name: str) -> dict:
@@ -228,19 +239,24 @@ class Bookmark:
                     )
                     return {
                         "success": True,
-                        "message": BOOKMARK_DELETE_BOOKMARK_SUCCESS,
+                        "message": Bookmark.BOOKMARK_DELETE_BOOKMARK_SUCCESS,
                     }
                 else:
-                    return {"success": False, "message": BOOKMARK_DELETE_BOOKMARK_FAIL}
+                    return {
+                        "success": False,
+                        "message": Bookmark.BOOKMARK_DELETE_BOOKMARK_FAIL,
+                    }
             except Exception as e:
                 return {
                     "success": False,
-                    "message": BOOKMARK_DELETE_BOOKMARK_ERROR.format(message=str(e)),
+                    "message": Bookmark.BOOKMARK_DELETE_BOOKMARK_ERROR.format(
+                        message=str(e)
+                    ),
                 }
         else:
             return {
                 "success": False,
-                "message": BOOKMARK_DELETE_BOOKMARK_ERROR_1.format(
+                "message": Bookmark.BOOKMARK_DELETE_BOOKMARK_ERROR_1.format(
                     message=bookmark_name
                 ),
             }
@@ -256,11 +272,16 @@ class Bookmark:
             Storage.delete_database_record_in_table(
                 self.db_instance, Bookmark.sql_delete_bookmark_records
             )
-            return {"success": True, "message": BOOKMARK_DELETE_ALL_BOOKMARK_SUCCESS}
+            return {
+                "success": True,
+                "message": Bookmark.BOOKMARK_DELETE_ALL_BOOKMARK_SUCCESS,
+            }
         except Exception as e:
             return {
                 "success": False,
-                "message": BOOKMARK_DELETE_ALL_BOOKMARK_ERROR.format(message=str(e)),
+                "message": Bookmark.BOOKMARK_DELETE_ALL_BOOKMARK_ERROR.format(
+                    message=str(e)
+                ),
             }
 
     def export_bookmarks(self, export_file_name: str = "bookmarks") -> str:
@@ -281,8 +302,8 @@ class Bookmark:
             Exception: If the export file name is invalid or an error occurs during export.
         """
         if not isinstance(export_file_name, str) or not export_file_name:
-            error_message = BOOKMARK_EXPORT_BOOKMARK_ERROR.format(
-                message=BOOKMARK_EXPORT_BOOKMARK_VALIDATION_ERROR
+            error_message = Bookmark.BOOKMARK_EXPORT_BOOKMARK_ERROR.format(
+                message=Bookmark.BOOKMARK_EXPORT_BOOKMARK_VALIDATION_ERROR
             )
             logger.error(error_message)
             raise Exception(error_message)
@@ -312,7 +333,9 @@ class Bookmark:
                 "json",
             )
         except Exception as e:
-            error_message = BOOKMARK_EXPORT_BOOKMARK_ERROR.format(message=str(e))
+            error_message = Bookmark.BOOKMARK_EXPORT_BOOKMARK_ERROR.format(
+                message=str(e)
+            )
             logger.error(error_message)
             raise Exception(error_message)
 

--- a/moonshot/src/bookmark/bookmark_arguments.py
+++ b/moonshot/src/bookmark/bookmark_arguments.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from typing import ClassVar
 
-from moonshot.src.messages_constants import (
-    BOOKMARK_ARGUMENTS_FROM_TUPLE_TO_DICT_VALIDATION_ERROR,
-)
+from pydantic import BaseModel, Field
 
 
 class BookmarkArguments(BaseModel):
+    BOOKMARK_ARGUMENTS_FROM_TUPLE_TO_DICT_VALIDATION_ERROR: ClassVar[
+        str
+    ] = "[BookmarkArguments] Failed to convert to dictionary because of the insufficient number of values."  # noqa: E501
+
     name: str = Field(min_length=1)
     prompt: str = Field(min_length=1)
     prepared_prompt: str = Field(min_length=1)
@@ -33,7 +35,9 @@ class BookmarkArguments(BaseModel):
             ValueError: If the number of values in the tuple is less than 10.
         """
         if len(values) < 10:
-            raise ValueError(BOOKMARK_ARGUMENTS_FROM_TUPLE_TO_DICT_VALIDATION_ERROR)
+            raise ValueError(
+                BookmarkArguments.BOOKMARK_ARGUMENTS_FROM_TUPLE_TO_DICT_VALIDATION_ERROR
+            )
 
         return {
             "name": values[1],

--- a/moonshot/src/connectors_endpoints/connector_endpoint.py
+++ b/moonshot/src/connectors_endpoints/connector_endpoint.py
@@ -7,14 +7,6 @@ from moonshot.src.configs.env_variables import EnvVariables
 from moonshot.src.connectors_endpoints.connector_endpoint_arguments import (
     ConnectorEndpointArguments,
 )
-from moonshot.src.messages_constants import (
-    CONNECTOR_ENDPOINT_CREATE_ERROR,
-    CONNECTOR_ENDPOINT_DELETE_ERROR,
-    CONNECTOR_ENDPOINT_GET_AVAILABLE_ITEMS_ERROR,
-    CONNECTOR_ENDPOINT_READ_ERROR,
-    CONNECTOR_ENDPOINT_READ_INVALID,
-    CONNECTOR_ENDPOINT_UPDATE_ERROR,
-)
 from moonshot.src.storage.storage import Storage
 from moonshot.src.utils.log import configure_logger
 
@@ -23,6 +15,23 @@ logger = configure_logger(__name__)
 
 
 class ConnectorEndpoint:
+    CONNECTOR_ENDPOINT_CREATE_ERROR = (
+        "[ConnectorEndpoint] Failed to create connector endpoint: {message}"
+    )
+    CONNECTOR_ENDPOINT_DELETE_ERROR = (
+        "[ConnectorEndpoint] Failed to delete connector endpoint: {message}"
+    )
+    CONNECTOR_ENDPOINT_GET_AVAILABLE_ITEMS_ERROR = (
+        "[ConnectorEndpoint] Failed to get available connector endpoints: {message}"
+    )
+    CONNECTOR_ENDPOINT_READ_ERROR = (
+        "[ConnectorEndpoint] Failed to read connector endpoint: {message}"
+    )
+    CONNECTOR_ENDPOINT_READ_INVALID = "Invalid connector endpoint id - {ep_id}"
+    CONNECTOR_ENDPOINT_UPDATE_ERROR = (
+        "[ConnectorEndpoint] Failed to update connector endpoint: {message}"
+    )
+
     @staticmethod
     @validate_call
     def create(ep_args: ConnectorEndpointArguments) -> str:
@@ -67,7 +76,9 @@ class ConnectorEndpoint:
             return ep_id
 
         except Exception as e:
-            logger.error(CONNECTOR_ENDPOINT_CREATE_ERROR.format(message=str(e)))
+            logger.error(
+                ConnectorEndpoint.CONNECTOR_ENDPOINT_CREATE_ERROR.format(message=str(e))
+            )
             raise e
 
     @staticmethod
@@ -94,12 +105,18 @@ class ConnectorEndpoint:
         try:
             endpoint_details = ConnectorEndpoint._read_endpoint(ep_id)
             if not endpoint_details:
-                raise RuntimeError(CONNECTOR_ENDPOINT_READ_INVALID.format(ep_id=ep_id))
+                raise RuntimeError(
+                    ConnectorEndpoint.CONNECTOR_ENDPOINT_READ_INVALID.format(
+                        ep_id=ep_id
+                    )
+                )
 
             return ConnectorEndpointArguments(**endpoint_details)
 
         except Exception as e:
-            logger.error(CONNECTOR_ENDPOINT_READ_ERROR.format(message=str(e)))
+            logger.error(
+                ConnectorEndpoint.CONNECTOR_ENDPOINT_READ_ERROR.format(message=str(e))
+            )
             raise e
 
     @staticmethod
@@ -167,7 +184,9 @@ class ConnectorEndpoint:
             return True
 
         except Exception as e:
-            logger.error(CONNECTOR_ENDPOINT_UPDATE_ERROR.format(message=str(e)))
+            logger.error(
+                ConnectorEndpoint.CONNECTOR_ENDPOINT_UPDATE_ERROR.format(message=str(e))
+            )
             raise e
 
     @staticmethod
@@ -194,7 +213,9 @@ class ConnectorEndpoint:
             return True
 
         except Exception as e:
-            logger.error(CONNECTOR_ENDPOINT_DELETE_ERROR.format(message=str(e)))
+            logger.error(
+                ConnectorEndpoint.CONNECTOR_ENDPOINT_DELETE_ERROR.format(message=str(e))
+            )
             raise e
 
     @staticmethod
@@ -234,6 +255,8 @@ class ConnectorEndpoint:
 
         except Exception as e:
             logger.error(
-                CONNECTOR_ENDPOINT_GET_AVAILABLE_ITEMS_ERROR.format(message=str(e))
+                ConnectorEndpoint.CONNECTOR_ENDPOINT_GET_AVAILABLE_ITEMS_ERROR.format(
+                    message=str(e)
+                )
             )
             raise e

--- a/tests/unit-tests/src/test_connector.py
+++ b/tests/unit-tests/src/test_connector.py
@@ -13,18 +13,22 @@ from moonshot.src.connectors.connector_prompt_arguments import ConnectorPromptAr
 from moonshot.src.connectors_endpoints.connector_endpoint_arguments import (
     ConnectorEndpointArguments,
 )
-from moonshot.src.messages_constants import (
-    CONNECTOR_CREATE_CONNECTOR_ENDPOINT_ARGUMENTS_VALIDATION_ERROR,
-    CONNECTOR_CREATE_ERROR,
-    CONNECTOR_GET_AVAILABLE_ITEMS_ERROR,
-    CONNECTOR_GET_PREDICTION_ARGUMENTS_CONNECTOR_VALIDATION_ERROR,
-    CONNECTOR_GET_PREDICTION_ARGUMENTS_GENERATED_PROMPT_VALIDATION_ERROR,
-    CONNECTOR_GET_PREDICTION_ERROR,
-    CONNECTOR_LOAD_CONNECTOR_ENDPOINT_ARGUMENTS_VALIDATION_ERROR,
-    CONNECTOR_LOAD_CONNECTOR_INSTANCE_RUNTIME_ERROR,
-    CONNECTOR_PERFORM_RETRY_CALLBACK_ERROR,
-    CONNECTOR_SET_SYSTEM_PROMPT_VALIDATION_ERROR,
+
+CONNECTOR_CREATE_CONNECTOR_ENDPOINT_ARGUMENTS_VALIDATION_ERROR = "[Connector] The 'ep_args' argument must be an instance of ConnectorEndpointArguments and not None."  # noqa: E501
+CONNECTOR_CREATE_ERROR = "[Connector] Failed to create connector: {message}"
+CONNECTOR_GET_AVAILABLE_ITEMS_ERROR = (
+    "[Connector] Failed to get available connectors: {message}"
 )
+CONNECTOR_GET_PREDICTION_ARGUMENTS_CONNECTOR_VALIDATION_ERROR = "[Connector] The 'connector' argument must be an instance of Connector and not None."  # noqa: E501
+CONNECTOR_GET_PREDICTION_ARGUMENTS_GENERATED_PROMPT_VALIDATION_ERROR = "[Connector] The 'generated_prompt' argument must be an instance of ConnectorPromptArguments and not None."  # noqa: E501
+CONNECTOR_GET_PREDICTION_ERROR = "[Connector ID: {connector_id}] Prompt Index {prompt_index} failed to get prediction: {message}"  # noqa: E501
+CONNECTOR_LOAD_CONNECTOR_ENDPOINT_ARGUMENTS_VALIDATION_ERROR = "[Connector] The 'ep_args' argument must be an instance of ConnectorEndpointArguments and not None."  # noqa: E501
+CONNECTOR_LOAD_CONNECTOR_INSTANCE_RUNTIME_ERROR = (
+    "[Connector] Failed to get connector instance: {message}"
+)
+CONNECTOR_PERFORM_RETRY_CALLBACK_ERROR = "[Connector ID: {connector_id}] Attempt {attempt_no} failed due to error: {message}"  # noqa: E501
+CONNECTOR_SET_SYSTEM_PROMPT_VALIDATION_ERROR = "[Connector] The 'system_prompt' argument must be an instance of string and not None."  # noqa: E501
+
 from moonshot.src.storage.storage import Storage
 
 

--- a/tests/unit-tests/src/test_connector_endpoint.py
+++ b/tests/unit-tests/src/test_connector_endpoint.py
@@ -10,13 +10,17 @@ from moonshot.src.connectors_endpoints.connector_endpoint import ConnectorEndpoi
 from moonshot.src.connectors_endpoints.connector_endpoint_arguments import (
     ConnectorEndpointArguments,
 )
-from moonshot.src.messages_constants import (
-    CONNECTOR_ENDPOINT_CREATE_ERROR,
-    CONNECTOR_ENDPOINT_GET_AVAILABLE_ITEMS_ERROR,
-    CONNECTOR_ENDPOINT_UPDATE_ERROR,
-)
 from moonshot.src.storage.storage import Storage
 
+CONNECTOR_ENDPOINT_CREATE_ERROR = (
+    "[ConnectorEndpoint] Failed to create connector endpoint: {message}"
+)
+CONNECTOR_ENDPOINT_GET_AVAILABLE_ITEMS_ERROR = (
+    "[ConnectorEndpoint] Failed to get available connector endpoints: {message}"
+)
+CONNECTOR_ENDPOINT_UPDATE_ERROR = (
+    "[ConnectorEndpoint] Failed to update connector endpoint: {message}"
+)
 
 class TestCollectionConnectorEndpoint:
     # ------------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Moving error messages back to individual files

## Motivation and Context

Initially the team wanted to place all error messages in a file so that it is easier to maintain. We subsequently realised that it requires more effort for contributors to update their error messages in a separate file, and so we are moving the error messages back to individual files

## Type of Change
Routine tasks, maintenance, or tooling changes 


## How to Test

- Trigger error msgs to test. However, there is no logic change to codes so no intensive testing required

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [x]  I have added appropriate unit tests or functional tests for the changes made.
- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [x]  I have added any necessary dependencies or packages to the project's build configuration.
- [x]  I have performed a self-review of my own code.
- [x]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>